### PR TITLE
Add link to team manual

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -15,3 +15,5 @@ Use this technical documentation to find out how to:
 - integrate your service with GOV.UK Accounts
 
 [Contact the GOV.UK Account team](https://www.account.publishing.service.gov.uk/feedback) if you have any questions or feedback.
+
+If you are a member of the GOV.UK Account team and need to find out information on internal GOV.UK Account team processes, see the [GOV.UK Account team manual](https://team-manual.account.publishing.service.gov.uk/#gov-uk-account-team-manual) for more information.


### PR DESCRIPTION
Add link to team manual into tech docs.

https://trello.com/c/kvsu8aMP/562-increase-tech-docs-and-team-manual-findability