### PR TITLE
Update accessibility statement

### DIFF
--- a/source/accessibility.html.md.erb
+++ b/source/accessibility.html.md.erb
@@ -23,7 +23,7 @@ We've also written the website in plain English to make it as simple as possible
 
 ## How accessible the GOV.UK Account technical documentation is
 
-We know some parts of this website are not fully accessible because there are issues caused by our Technical Documentation Template.
+This website is fully compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21/) AA standard.
 
 ## Feedback and contact information
 
@@ -47,39 +47,18 @@ GDS is committed to making its website accessible, in accordance with the Public
 
 ## Compliance status
 
-This website is partially compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21/) AA standard, due to the non-compliances listed in this statement.
-
-### Non-accessible content
-
-Some of the content in the GOV.UK Account technical documentation is non-accessible for the following reasons.
-
-#### Non-compliance with the accessibility regulations
-
-Some parts of the GOV.UK Account technical documentation are not fully accessible because of [issues caused by our Technical Documentation Template](https://tdt-documentation.london.cloudapps.digital/accessibility/#using-the-technical-documentation-template-for-your-own-documentation).
+This website is fully compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21/) AA standard.
 
 ## How we tested this website
 
-We last tested the GOV.UK Account technical documentation for accessibility issues in January 2021.
-
-We used manual and automated tests to look for issues such as:
-
-- lack of keyboard accessibility
-- link text that’s not descriptive
-- non-unique or non-hierarchical headings
-- italics, bold or block capital formatting
-- inaccessible formatting in general
-- inaccessible language
-- inaccessible diagrams or images
-- lack of colour contrast for text, important graphics and controls
-- images not having meaningful alt text
-- problems when using assistive technologies such as screen readers and screen magnifiers
+We last tested the GOV.UK Account technical documentation for accessibility issues in March 2021.
 
 ## What we’re doing to improve accessibility
 
-We plan to fix the accessibility issues with the Technical Documentation Template by the end of March 2021.
+We will maintain the technical documentation to make sure it remains fully compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21/) AA standard.
 
 ## Preparation of this accessibility statement
 
-This statement was prepared on 11 January 2021. It was last reviewed on 11 January 2021.
+This statement was prepared on 11 January 2021. It was last reviewed on 19 March 2021.
 
-This website was last tested in January 2021. The test was carried out by the technical writing team at GDS. We used the [WAVE Web Accessibility Evaluation Tool](https://wave.webaim.org/) and a checklist we created with the help of the GDS accessibility team. We tested all the website's pages.
+This website was last tested in March 2021. The test was carried out by the technical writing team at GDS. We used the [WAVE Web Accessibility Evaluation Tool](https://wave.webaim.org/) and a checklist we created with the help of the GDS accessibility team. We tested all the website's pages.


### PR DESCRIPTION
The GOV.UK Account tech docs and team manual now use version 2.2.1 of the tech docs template, which incorporates the latest accessibility fixes.

This PR update the tech docs accessibility statement to reflect that it is now fully compliant with the WCAG 2.1 AA standard.

Trello card: https://trello.com/c/0og74M7R/677-update-tech-docs-and-team-manual-to-use-version-221-of-the-tech-docs-template