### PR TITLE
Update tech doc template to 2.2.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,7 +43,7 @@ GEM
     fast_blank (1.0.0)
     fastimage (2.2.3)
     ffi (1.15.0)
-    govuk_tech_docs (2.2.1)
+    govuk_tech_docs (2.2.2)
       chronic (~> 0.10.2)
       middleman (~> 4.0)
       middleman-autoprefixer (~> 2.10.0)
@@ -64,7 +64,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    kramdown (2.3.0)
+    kramdown (2.3.1)
       rexml
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)


### PR DESCRIPTION
Update tech doc template to 2.2.2

Trello card: https://trello.com/c/FXAqf1yO/689-update-tech-docs-and-team-manual-to-use-version-222-of-the-tech-docs-template